### PR TITLE
Fix cache identifiers, calculate search time

### DIFF
--- a/cache.php
+++ b/cache.php
@@ -40,6 +40,6 @@ function identifier_for_query ($query, $type, $license) {
     $identifier = strtolower($identifier);
     $identifier = str_replace(" ", "+", $identifier);
     //$identifier = preg_replace("/[^a-zA-Z]+/", "", $query);
-    $identifier = $type . "-" . $license . "--results-" . $identifier . ".json";
+    $identifier = $type . "-" . $license . "--results-" . $identifier;
     return $identifier;
 }

--- a/filesystem-cache.php
+++ b/filesystem-cache.php
@@ -50,7 +50,7 @@ function search_results_from_cache ($filename) {
 
 function fetch_results_maybe_cached ($query, $type, $license, $count) {
     $identifier = identifier_for_query($query, $type, $license);
-    $filename = $type . '/' . $identifier;
+    $filename = $type . '/' . $identifier . ".json";
 
     if (! file_exists($filename)) {
         $foo = cache_search_results ($filename, $query, $type, $license,

--- a/search.php
+++ b/search.php
@@ -22,6 +22,8 @@
 
   */
 
+$search_start_time = microtime(true);
+
 //require_once('database.php');
 require_once('templating.php');
 require_once('data/Items.php');
@@ -46,10 +48,10 @@ if ($query !="")
     $was_cached;
     $results = fetch_results_maybe_cached($query, $type, $license, $count);
     if ($results->cached) {
-        $smarty->assign('from', "Cached (" . $results->cache ."): "
+        $smarty->assign('from', "cached (" . $results->cache ."): "
                               . $results->identifier);
     } else {
-        $smarty->assign('from','live');
+        $smarty->assign('from', 'live');
     }
 
     //$foo_of_at_most_requested_length = array_slice($results->results,
@@ -63,5 +65,14 @@ if ($query !="")
 
 }
 
+// Not the most accurate calculation, as it excludes smarty rendering
+// Move final calculation into the template or even postprocess somehow?
+$search_time = (microtime(true) - $search_start_time);
+if($search_time < 1.0) {
+    $search_time = round($search_time * 1000000) . ' &mu;s';
+} else {
+    $search_time = $search_time . " seconds";
+}
+$smarty->assign('search_time', $search_time);
 $smarty->assign('headerfile', 'welcome-header.tpl');
 $smarty->display('search.tpl');

--- a/themes/cc/templates/search.tpl
+++ b/themes/cc/templates/search.tpl
@@ -21,5 +21,6 @@
 <div class="container">
 
 <hr class="clearfix" />
-<p class="text-muted"><small>{$from}</small></p>
+<p class="text-muted"><small>{$from}</small><br />
+  <small>approx. {$search_time}</small></p>
 {include file='footer.tpl'}


### PR DESCRIPTION
Minor fixes and improvements. Redis shouldn't have ".json" at the end of identifiers. Calculate the time taken to complete the search and display it on the page.